### PR TITLE
Add items key to array properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ## Changelog
 
+### 2022-03-09
+
+* Add `items` to `OtherRequirements.qualificationSystemConditions` and `OtherRequirements.qualificationSystemMethods`
+
 ### 2020-04-24
 
 * Add `minProperties`, `minItems` and/or `minLength` properties.

--- a/release-schema.json
+++ b/release-schema.json
@@ -54,6 +54,10 @@
             "array",
             "null"
           ],
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "minItems": 1,
           "uniqueItems": true
         },
@@ -64,6 +68,10 @@
             "array",
             "null"
           ],
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "minItems": 1,
           "uniqueItems": true
         },


### PR DESCRIPTION
I noticed that data in which the OCDS for the European Union extension is declared causes the DRT's convert to spreadsheet feature to fail with `KeyError('items',)` ([example](https://standard.open-contracting.org/review/data/49fef04f-a701-487e-829c-936de35af45f)).

This is because the `items` property is missing from `OtherRequirements.qualificationSystemConditions` and `OtherRequirements.qualificationSystemMethods`, which are arrays.

Based on the example in the readme, it looks like these should be arrays of strings. I checked the PRs in this repo and the issues in https://github.com/open-contracting-extensions/european-union/issues and I couldn't find any discussions that suggested otherwise.

Once this PR is merged, the consolidated EU extension will need updating, too.